### PR TITLE
scroll to both words that are only traditional in the list

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -719,7 +719,7 @@ export default class ZhongwenReaderPlugin extends Plugin {
 	}
 	
 	
-	public scrollToWordInActiveFile(word: string) {
+	public scrollToWordInActiveFile(entry: VocabEntry) {
 		const view = this.currentMarkdownView;
 		const mode = view?.getMode?.() ?? "source"; // fallback to "source" if undefined
 
@@ -748,7 +748,8 @@ export default class ZhongwenReaderPlugin extends Plugin {
 		}
 		
 		for (const line of Array.from(lines)) {
-			if (line.textContent?.includes(word)) {
+			const currentText = line.textContent;
+			if (currentText && (currentText.includes(entry.simplified) || currentText.includes(entry.traditional))) {
 				(line as HTMLElement).scrollIntoView({ behavior: "smooth", block: "center" });
 	
 				// Highlight the line briefly, delayed by 100 to allow DOM to scroll first
@@ -868,7 +869,7 @@ class VocabSidebarView extends ItemView {
 
 			// Make wrapper clickable
 			wrapper.onclick = () => {
-				this.plugin.scrollToWordInActiveFile(entry.simplified);
+				this.plugin.scrollToWordInActiveFile(entry);
 			};
 		}
 	}	


### PR DESCRIPTION
> clicking on a word from the sidebar and it wont scroll to that position in the file for some of them

this was because we were previously searching only for simplified in the list. however , if your document had traditional version, we wouldn't find it

also considered another feature  -- if you clicked the word again, to cycle to the next instance of the word, but didn't want to add scope creep