### PR TITLE
Added some additional flashcard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Zhongwen Reader is a lightweight hover dictionary plugin for Obsidian that makes
 - 📥 **Save Words:** Use the command palette to save hovered words to a vocab list.
   - 🧠 **Sentence Capture:** Optionally save example sentences when adding vocab.
 - 📋 **Sidebar View:** See vocab from the current note and jump to word locations.
-- 🗃️ **Flashcard Export:** Export saved vocab as markdown flashcards for the Spaced Repetition plugin.
+- 🗃️ **Flashcard Export:** Export saved vocab as markdown flashcards for the Spaced Repetition plugin or CSV flashcards for Anki import.
 
 > ⚠️ **Note:** Example sentences are saved to `vocab.json` but not yet used in flashcards or sidebar. Support coming soon.
 
@@ -64,7 +64,7 @@ Want a feature?
 3. Include your use case and why it would help
 
 # 📦 Coming soon
-- [ ] Export to Anki .apkg
+- [x] Export to Anki
 - [ ] Toggle vocab sidebar
 - [ ] Database-style vocab view
 - [ ] Built-in spaced repetition with cloze support

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Zhongwen Reader is a lightweight hover dictionary plugin for Obsidian that makes
 - Save a word from the hover popup using the command palette.
 - Open the 📘 Sidebar View to browse words in the current note.
 - Use the palette to Export Vocab to Flashcards or toggle HSK highlights.
+- For Anki export, use the palette to Export Vocab to CSV. Anki can import this CSV file with field separator set to semicolon. 
 
 # ⚙️ Settings
 - Save Sentence: Automatically capture the sentence where the word appears.


### PR DESCRIPTION
Adding a PR to add two features:

1. Export of vocab list to semicolon-separated CSV file. Anki (and other flashcard programs) can natively import these into flashcards. 
2.  Added the "#flashcards" tag to the Vocab list export to markdown file. The reason is that by default the Anki SRS plugin only checks for files with the #flashcards tag, so the #ChineseVocab tag currently in the markdown file has to be manually added to the SRS configuration for this feature to work. 