### PR TITLE
CSV (hence Anki) support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Zhongwen Reader is a lightweight hover dictionary plugin for Obsidian that makes
 - Save a word from the hover popup using the command palette.
 - Open the 📘 Sidebar View to browse words in the current note.
 - Use the palette to Export Vocab to Flashcards or toggle HSK highlights.
+- For Anki export, use the palette to Export Vocab to CSV. Anki can import this CSV file with field separator set to semicolon. 
 
 # ⚙️ Settings
 - Save Sentence: Automatically capture the sentence where the word appears.


### PR DESCRIPTION

Adding a PR to add two features:

 1. Export of vocab list to semicolon-separated CSV file. Anki (and other flashcard programs) can natively import these into flashcards.


 2. Added the "#flashcards" tag to the Vocab list export to markdown file. The reason is that by default the Anki SRS plugin only checks for files with the #flashcards tag, so the #ChineseVocab tag currently in the markdown file has to be manually added to the SRS configuration for this feature to work.

